### PR TITLE
fixes entry file name

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stream-md5",
   "version": "0.0.2",
   "description": "MD5 implementation in JS that allows progressive hashing and is binary safe",
-  "main": "jsMD5.js",
+  "main": "md5.js",
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
It was pointing to the wrong file, resulting in a "Cannot find module" error
