### PR TITLE
remove ifs around function expressions

### DIFF
--- a/md5.js
+++ b/md5.js
@@ -16,34 +16,30 @@
         HAS_UINT8ARRAY = (typeof Uint8Array !== 'undefined')
         undefined;
 
-    if (HAS_BUFFERS) {
-        function bufferCharCodeAt(buf, offset) {
-            return buf.readUInt8(offset);
+    function bufferCharCodeAt(buf, offset) {
+        return buf.readUInt8(offset);
+    }
+    function bufferSubstring(buf, start, end) {
+        return buf.slice(start, end);
+    }
+    function bufferConcat(buf, buf2) {
+        if (buf === null) {
+            return buf2;
         }
-        function bufferSubstring(buf, start, end) {
-            return buf.slice(start, end);
-        }
-        function bufferConcat(buf, buf2) {
-            if (buf === null) {
-                return buf2;
-            }
-            return Buffer.concat([buf, buf2]);
-        }
+        return Buffer.concat([buf, buf2]);
     }
 
-    if (HAS_UINT8ARRAY) {
-        function uint8ArraySubstring(uint8Array, start, end) {
-            return uint8Array.subarray(start, end);
+    function uint8ArraySubstring(uint8Array, start, end) {
+        return uint8Array.subarray(start, end);
+    }
+    function uint8ArrayConcat(uint8Array1, uint8Array2) {
+        if (uint8Array1 === null) {
+            return uint8Array2;
         }
-        function uint8ArrayConcat(uint8Array1, uint8Array2) {
-            if (uint8Array1 === null) {
-                return uint8Array2;
-            }
-            var tmp = new Uint8Array(uint8Array1.length + uint8Array2.length);
-            tmp.set(uint8Array1, 0);
-            tmp.set(uint8Array2, uint8Array1.length);
-            return tmp;
-        }
+        var tmp = new Uint8Array(uint8Array1.length + uint8Array2.length);
+        tmp.set(uint8Array1, 0);
+        tmp.set(uint8Array2, uint8Array1.length);
+        return tmp;
     }
 
     function stringCharCodeAt(string, offset) {


### PR DESCRIPTION
Function expressions are hoisted outside of block scopes, in other words, JavaScript will define the functions anyway. Thus, the `HAS_UINT8ARRAY` and `HAS_BUFFERS` if statements surrounding the functions do not play any role in this library.

JavaScript bundlers, such as Webpack, are assuming you are trying to declare the function inside the if's block scope only to be used inside the if statement. Like so:

```js
if (HAS_BUFFERS) {
    var _bufferCharCodeAt = function (buf, offset) {
        return buf.readUInt8(offset);
    }
	// ...
}

// later in the code, webpack assumes "bufferCharCodeAt" is global:
something = bufferCharCodeAt; // note that there is no underscore.
```

This causes the library to error out with "bufferCharCodeAt is not defined" error. Which can be quickly mitigated by understanding scope in JavaScript and removing the unnecessary if statements from function expression declarations.
